### PR TITLE
Fix update process

### DIFF
--- a/src/containers/EditorContainer.js
+++ b/src/containers/EditorContainer.js
@@ -398,10 +398,10 @@ export class EditorContainer extends React.Component {
    * Handles update by parsing data and submitting a request to update the design.
    */
   handleUpdate = () => {
-    const design = {
-      id: this.props.design.get("id"),
-      variations: this.generateDesignVariations()
-    };
+    const design = this.props.design.set(
+      "variations",
+      this.generateDesignVariations()
+    );
     this.props.onUpdate(design);
   };
 


### PR DESCRIPTION
The entire Design object was not being passed to the update call as expected causing the update process to fail.

Updated the logic to return the entire Design object when updating.