### PR TITLE
View color management improvements

### DIFF
--- a/src/components/view/InvalidColorsModal.js
+++ b/src/components/view/InvalidColorsModal.js
@@ -1,0 +1,81 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { Button, Modal, P, H2, Icon } from "../../theme";
+
+/**
+ * Styling for the modal window itself
+ */
+export const StyleWrapper = styled.div`
+  .buttons {
+    display: flex;
+
+    button {
+      flex-grow: 1;
+      margin: 8px 8px 0;
+    }
+  }
+`;
+
+/**
+ * Modal prompt prompts the user for a single string value and has submit and cancel buttons.
+ */
+class ModalConfirm extends React.Component {
+  static propTypes = {
+    hasInvalidColors: PropTypes.bool.isRequired
+  };
+
+  state = {
+    /**
+     * Is the modal currently open?
+     */
+    isOpen: null
+  };
+
+  static getDerivedStateFromProps(props, state) {
+    if (state.isOpen === null) {
+      state.isOpen = props.hasInvalidColors;
+    }
+  }
+
+  /**
+   * Handles the closing by closing/resetting the modal and triggering onCancel.
+   */
+  handleClose = () => {
+    this.setState({ isOpen: false });
+  };
+
+  render() {
+    return (
+      <Modal
+        isOpen={this.state.isOpen || false}
+        onBackdropClick={this.handleClose}
+        modalContent={
+          <StyleWrapper>
+            <H2>
+              <Icon icon="exclamation-circle" /> Invalid colors
+            </H2>
+            <br />
+            <P>
+              This design contains colors that are no longer a part of this
+              product&#39;s color palette. Please remake this design to ensure
+              that it uses the color palette that is currently supported by the
+              manufacturer.
+            </P>
+            <div className="buttons">
+              <Button
+                className="testing_close"
+                type="button"
+                onClick={this.handleClose}
+              >
+                Close
+              </Button>
+            </div>
+          </StyleWrapper>
+        }
+      />
+    );
+  }
+}
+
+export default ModalConfirm;

--- a/src/components/view/Sidebar.js
+++ b/src/components/view/Sidebar.js
@@ -8,6 +8,7 @@ import User from "../../models/User";
 import ColorTile from "../editor/ColorTile";
 import { Icon, FillToBottom, Sidebar as SidebarUI } from "../../theme";
 import { getAssetUrl } from "../../utils";
+import { success } from "../../theme/Alert";
 import ManufacturerLogo from "../ManufacturerLogo";
 import Svg from "../Svg";
 
@@ -131,7 +132,12 @@ const Sidebar = ({
         </sidebar.components.Heading>
         <FillToBottom offset={35}>
           {usedColors[selectedVariation].map(color => (
-            <sidebar.components.Item isLight key={color.color}>
+            <sidebar.components.Item
+              className="testing_used-color"
+              isLight
+              key={color.color}
+              onClick={() => success(color.name)}
+            >
               <ColorTile color={color.color} className="color-tile" />
               <span className="color-label"> {color.name}</span>
             </sidebar.components.Item>

--- a/src/components/view/View.js
+++ b/src/components/view/View.js
@@ -7,6 +7,7 @@ import Toolbar from "../editor/Toolbar";
 import Sidebar from "./Sidebar";
 import Canvas from "../editor/Canvas";
 import ErrorPage from "../ErrorPage";
+import InvalidColorsModal from "./InvalidColorsModal";
 
 const PageLayout = styled.div`
   display: flex;
@@ -33,6 +34,9 @@ const View = ({ match }) => (
       }
       return (
         <React.Fragment>
+          <InvalidColorsModal
+            hasInvalidColors={viewData.props.hasInvalidColors}
+          />
           <Toolbar
             design={viewData.props.design}
             hideOutlines={viewData.props.hideOutlines}

--- a/src/components/view/__unit__/InvalidColorsModal.test.js
+++ b/src/components/view/__unit__/InvalidColorsModal.test.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Modal from "../../../theme/Modal";
+import InvalidColorsModal from "../InvalidColorsModal";
+
+describe("InvalidColorsModal", () => {
+  let defaultProps;
+  beforeEach(() => {
+    defaultProps = {
+      hasInvalidColors: false
+    };
+  });
+  it("renders", () => {
+    shallow(<InvalidColorsModal {...defaultProps} />);
+  });
+
+  it("opens the modal when hasInvalidColors is true", () => {
+    expect.assertions(1);
+    defaultProps.hasInvalidColors = true;
+    const wrapper = shallow(<InvalidColorsModal {...defaultProps} />);
+    expect(wrapper.find(Modal).prop("isOpen")).toEqual(true);
+  });
+  it("closes the modal when clicking on the close button", () => {
+    expect.assertions(1);
+    const wrapper = shallow(<InvalidColorsModal {...defaultProps} />);
+    shallow(<div>{wrapper.find(Modal).prop("modalContent")}</div>)
+      .find(".testing_close")
+      .simulate("click");
+    expect(wrapper.find(Modal).prop("isOpen")).toEqual(false);
+  });
+  it("closes the modal when clicking on the backdrop", () => {
+    expect.assertions(1);
+    const wrapper = shallow(<InvalidColorsModal {...defaultProps} />);
+    wrapper.find(Modal).prop("onBackdropClick")();
+    expect(wrapper.find(Modal).prop("isOpen")).toEqual(false);
+  });
+});

--- a/src/components/view/__unit__/Sidebar.test.js
+++ b/src/components/view/__unit__/Sidebar.test.js
@@ -4,7 +4,10 @@ import { getMockDesign } from "../../../models/Design";
 import { getMockProduct } from "../../../models/Product";
 import { getMockManufacturer } from "../../../models/Manufacturer";
 import { getMockUser } from "../../../models/User";
+import { success } from "../../../theme/Alert";
 import Sidebar, { StyledSidebar } from "../Sidebar";
+
+jest.mock("../../../theme/Alert");
 
 describe("Sidebar", () => {
   let defaultProps;
@@ -110,5 +113,30 @@ describe("Sidebar", () => {
       .simulate("click");
     expect(defaultProps.onVariationSelect).toHaveBeenCalled();
     expect(defaultProps.onVariationSelect.mock.calls[0][0]).toEqual("1");
+  });
+  it("alerts the name of the color when a color is clicked", () => {
+    defaultProps.usedColors = {
+      Standard: [
+        {
+          name: "white",
+          color: "#ffffff"
+        },
+        {
+          name: "boogers",
+          color: "#00ff00"
+        }
+      ]
+    };
+
+    const wrapper = shallow(<Sidebar {...defaultProps} />);
+    const sidebarUI = shallow(
+      <div>{wrapper.find(StyledSidebar).prop("children")(sidebarData)}</div>
+    );
+    sidebarUI
+      .find(".testing_used-color")
+      .at(1)
+      .simulate("click");
+
+    expect(success).toHaveBeenCalledWith("boogers");
   });
 });

--- a/src/containers/__unit__/ViewContainer.test.js
+++ b/src/containers/__unit__/ViewContainer.test.js
@@ -96,4 +96,154 @@ describe("ViewContainer", () => {
     );
     expect(wrapper.find(".target").text()).toEqual("Red, Black");
   });
+  it("does not provide colors from non-colorable panels as used colors", () => {
+    expect.assertions(1);
+    defaultProps.product = getMockProduct({
+      colors: [
+        {
+          name: "Red",
+          color: "#ff0000"
+        },
+        {
+          name: "Black",
+          color: "#000000"
+        },
+        {
+          name: "White",
+          color: "#FFFFFF"
+        }
+      ]
+    });
+    defaultProps.design = getMockDesign({
+      variations: [
+        {
+          id: "0",
+          name: "Standard",
+          svg: `<svg viewBox="0 0 1963.2 651.1">
+              <polygon fill="#FF0000" stroke="#000000" points="1769.7,48.9 1642.3,373.9 992.1,137.3 990,40.9 1069,40.6 1365.9,41.3 1549,42.7 1604.8,43.8 "/>
+              <polygon data-id="p1" fill="#000000" stroke="#000000" points="1769.7,48.9 1642.3,373.9 992.1,137.3 990,40.9 1069,40.6 1365.9,41.3 1549,42.7 1604.8,43.8 "/>
+              <polygon data-id="p2" fill="#000000" stroke="#000000" points="1769.7,48.9 1642.3,373.9 992.1,137.3 990,40.9 1069,40.6 1365.9,41.3 1549,42.7 1604.8,43.8 "/>
+            </svg>`,
+          primary: false
+        },
+        {
+          id: "1",
+          name: "Vented",
+          svg: "",
+          primary: true
+        }
+      ]
+    });
+    const wrapper = shallow(
+      <ViewContainer {...defaultProps}>
+        {viewData => (
+          <div className="target">
+            {viewData.props.usedColors["0"].map(color => color.name).join(", ")}
+          </div>
+        )}
+      </ViewContainer>
+    );
+    expect(wrapper.find(".target").text()).toEqual("Black");
+  });
+  it("identifies the colors used in each panel", () => {
+    defaultProps.product = getMockProduct({
+      colors: [
+        {
+          name: "Red",
+          color: "#ff0000"
+        },
+        {
+          name: "Black",
+          color: "#000000"
+        },
+        {
+          name: "White",
+          color: "#FFFFFF"
+        }
+      ]
+    });
+    defaultProps.design = getMockDesign({
+      variations: [
+        {
+          id: "0",
+          name: "Standard",
+          svg: `<svg viewBox="0 0 1963.2 651.1">
+              <polygon fill="#FF0000" stroke="#000000" points="1769.7,48.9 1642.3,373.9 992.1,137.3 990,40.9 1069,40.6 1365.9,41.3 1549,42.7 1604.8,43.8 "/>
+              <polygon data-id="p1" fill="#000000" stroke="#000000" points="1769.7,48.9 1642.3,373.9 992.1,137.3 990,40.9 1069,40.6 1365.9,41.3 1549,42.7 1604.8,43.8 "/>
+              <polygon data-id="p2" fill="#000000" stroke="#000000" points="1769.7,48.9 1642.3,373.9 992.1,137.3 990,40.9 1069,40.6 1365.9,41.3 1549,42.7 1604.8,43.8 "/>
+            </svg>`,
+          primary: true
+        },
+        {
+          id: "1",
+          name: "Vented",
+          svg: "",
+          primary: false
+        }
+      ]
+    });
+    const wrapper = shallow(
+      <ViewContainer {...defaultProps}>
+        {viewData => (
+          <div className="target">
+            {JSON.stringify(viewData.props.currentVariationColors)}
+          </div>
+        )}
+      </ViewContainer>
+    );
+    expect(wrapper.find(".target").text()).toEqual(
+      '{"p1":{"color":"#000000","name":"Black"},"p2":{"color":"#000000","name":"Black"}}'
+    );
+  });
+
+  it("sets hasInvalidColors if the design contains invalid colors", () => {
+    defaultProps.product = getMockProduct({
+      colors: [
+        {
+          name: "Red",
+          color: "#ff0000"
+        },
+        {
+          name: "Black",
+          color: "#000000"
+        },
+        {
+          name: "White",
+          color: "#FFFFFF"
+        }
+      ]
+    });
+    defaultProps.design = getMockDesign({
+      variations: [
+        {
+          id: "0",
+          name: "Standard",
+          svg: `<svg viewBox="0 0 1963.2 651.1">
+              <polygon fill="#FF0000" stroke="#000000" points="1769.7,48.9 1642.3,373.9 992.1,137.3 990,40.9 1069,40.6 1365.9,41.3 1549,42.7 1604.8,43.8 "/>
+              <polygon data-id="p1" fill="#000000" stroke="#000000" points="1769.7,48.9 1642.3,373.9 992.1,137.3 990,40.9 1069,40.6 1365.9,41.3 1549,42.7 1604.8,43.8 "/>
+              <polygon data-id="p2" fill="#00ff00" stroke="#000000" points="1769.7,48.9 1642.3,373.9 992.1,137.3 990,40.9 1069,40.6 1365.9,41.3 1549,42.7 1604.8,43.8 "/>
+            </svg>`,
+          primary: true
+        },
+        {
+          id: "1",
+          name: "Vented",
+          svg: "",
+          primary: false
+        }
+      ]
+    });
+    const wrapper = shallow(
+      <ViewContainer {...defaultProps}>
+        {viewData => (
+          <div className="target">
+            {viewData.props.hasInvalidColors
+              ? "hasInvalidColors"
+              : "test failed"}
+          </div>
+        )}
+      </ViewContainer>
+    );
+    expect(wrapper.find(".target").text()).toEqual("hasInvalidColors");
+  });
 });


### PR DESCRIPTION
* Added functionality to display a popup when clicking on a color in the sidebar on View pages which displays the name of the color clicked. This will be useful for mobile users, for whom the color name is typically hidden to save space.
* Added an modal popup that appears when loading a View page for a design that contains colors that no longer exist in the product's color palette
* Test updates